### PR TITLE
✨ chore: update Rust edition to 2024

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,12 +3,7 @@
 {
 	"name": "Tauri",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/universal:2",
-	"features": {
-		"ghcr.io/michidk/devcontainers-features/bun:1": {},
-		"ghcr.io/devcontainers/features/desktop-lite:1": {},
-        	"ghcr.io/devcontainers/features/rust:1": {}
-	}
+	"image": "mcr.microsoft.com/devcontainers/base:ubuntu",
 
 	// Use 'mounts' to make the cargo cache persistent in a Docker Volume.
 	// "mounts": [
@@ -20,7 +15,14 @@
 	// ]
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
-	// "features": {},
+	"features": {
+		"ghcr.io/prulloac/devcontainer-features/bun:1": {},
+		"ghcr.io/devcontainers/features/desktop-lite:1": {},
+        "ghcr.io/devcontainers/features/rust:1": {},
+		"ghcr.io/devcontainers-extra/features/apt-packages:1": {
+			"packages": "libwebkit2gtk-4.1-dev,build-essential,file,libxdo-dev,libssl-dev,libayatana-appindicator3-dev,librsvg2-dev" 
+		}
+	}
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,7 +18,7 @@
 	"features": {
 		"ghcr.io/prulloac/devcontainer-features/bun:1": {},
 		"ghcr.io/devcontainers/features/desktop-lite:1": {},
-        "ghcr.io/devcontainers/features/rust:1": {},
+		"ghcr.io/devcontainers/features/rust:1": {},
 		"ghcr.io/devcontainers-extra/features/apt-packages:1": {
 			"packages": "libwebkit2gtk-4.1-dev,build-essential,file,libxdo-dev,libssl-dev,libayatana-appindicator3-dev,librsvg2-dev" 
 		}

--- a/README.md
+++ b/README.md
@@ -2,7 +2,12 @@
 
 [//]:[![Stars](https://img.shields.io/github/stars/AR10Dev/tauri-solid-ts-tailwind-vite?style=social)](https://github.com/AR10Dev/tauri-solid-ts-tailwind-vite)
 [![Rust](https://img.shields.io/badge/Rust-black?style=for-the-badge&logo=rust&logoColor=#E57324)](https://github.com/AR10Dev/tauri-solid-ts-tailwind-vite)
-[![Typescript](https://img.shields.io/badge/TypeScript-007ACC?style=for-the-badge&logo=typescript&logoColor=white)](https://AR10Dev/tauri-solid-ts-tailwind-vite)
+[![Typescript](https://img.shields.io/badge/TypeScript-007ACC?style=for-the-badge&logo=typescript&logoColor=white)](https://github.com/AR10Dev/tauri-solid-ts-tailwind-vite)
+[![Solid JS](https://img.shields.io/badge/SolidJS-2C4F7C?style=for-the-badge&logo=solid&logoColor=white)](https://github.com/AR10Dev/tauri-solid-ts-tailwind-vite)
+[![Tailwind CSS](https://img.shields.io/badge/Tailwind_CSS-38B2AC?style=for-the-badge&logo=tailwind-css&logoColor=white)](https://github.com/AR10Dev/tauri-solid-ts-tailwind-vite)
+[![Vite](https://img.shields.io/badge/Vite-646CFF?style=for-the-badge&logo=vite&logoColor=white)](https://github.com/AR10Dev/tauri-solid-ts-tailwind-vite)
+[![Tauri](https://img.shields.io/badge/Tauri-24C8D8?style=for-the-badge&logo=tauri&logoColor=white)](https://github.com/AR10Dev/tauri-solid-ts-tailwind-vite)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=for-the-badge)](https://github.com/AR10Dev/tauri-solid-ts-tailwind-vite)
 
 A starter template for [Tauri](https://tauri.app) + [Solid](https://solidjs.com) App that comes preconfigured with [Vite](https://vitejs.dev),
 [TypeScript](https://typescriptlang.org), [Tailwind CSS](https://tailwindcss.com), [ESLint](https://eslint.org), [Prettier](https://prettier.io) and HMR (Hot Module Replacement).
@@ -82,7 +87,7 @@ It correctly bundles Solid in production mode and optimizes the binary for the b
 🎉 Congratulations, your app is ready to be release!
 
 ## Custom App Icon
-To generate your custom app icon you can follow this [guide](https://v2.tauri.app/reference/cli/#icon).<br>
+To generate your custom app icon you can follow this [guide](https://tauri.app/reference/cli/#icon).<br>
 Your new app icons will be located in `src-tauri/icons/` and remeber to update the `icon` field in `src-tauri/tauri.conf.json` with all your new icon path names.<br>
 
 ## Customize the tauri.conf.json

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["AR10"]
 license = "MIT"
 repository = "https://github.com/AR10Dev/tauri-solid-ts-tailwind-vite"
 default-run = "app"
-edition = "2021"
+edition = "2024"
 
 [lib]
 # The `_lib` suffix may seem redundant but it is necessary

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,3 +1,3 @@
 fn main() {
-  tauri_build::build()
+    tauri_build::build()
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,19 +1,19 @@
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-  #[cfg(debug_assertions)] // only enable instrumentation in development builds
-  let devtools = tauri_plugin_devtools::init();
+    #[cfg(debug_assertions)] // only enable instrumentation in development builds
+    let devtools = tauri_plugin_devtools::init();
 
-  let mut builder = tauri::Builder::default();
+    let mut builder = tauri::Builder::default();
 
-  #[cfg(debug_assertions)]
+    #[cfg(debug_assertions)]
     {
         builder = builder.plugin(devtools);
     }
 
-  builder
-    // .plugin( /* Add your Tauri plugin here */ )
-    // Add your commands here that you will call from your JS code  
-    // .invoke_handler(tauri::generate_handler![ /* Add your commands here */ ])
-    .run(tauri::generate_context!())
-    .expect("error while running tauri application");
+    builder
+        // .plugin( /* Add your Tauri plugin here */ )
+        // Add your commands here that you will call from your JS code
+        // .invoke_handler(tauri::generate_handler![ /* Add your commands here */ ])
+        .run(tauri::generate_context!())
+        .expect("error while running tauri application");
 }


### PR DESCRIPTION
This pull request includes updates to the development container configuration, improvements to the README file, and an update to the Rust edition in the `Cargo.toml` file. The most important changes are listed below:

### Development Container Configuration:

* [`.devcontainer/devcontainer.json`](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L6-R6): Changed the base image from `mcr.microsoft.com/devcontainers/universal:2` to `mcr.microsoft.com/devcontainers/base:ubuntu` and updated the features to include `bun`, `desktop-lite`, `rust`, and `apt-packages` with additional packages. [[1]](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L6-R6) [[2]](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L23-R25)

### Documentation Improvements:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L5-R10): Added badges for SolidJS, Tailwind CSS, Vite, Tauri, and MIT License to the README file. Corrected the link for the TypeScript badge.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L85-R90): Updated the link to the Tauri CLI icon generation guide.

### Rust Edition Update:

* [`src-tauri/Cargo.toml`](diffhunk://#diff-fe4c6a80a21e81339e2e0faeb9134d0f9636c168987df13c8abf1927a1caee39L9-R9): Updated the Rust edition from 2021 to 2024.