### PR TITLE
📦 chore(deps): Update tauri monorepo

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -19,12 +19,12 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [build-dependencies]
-tauri-build = { version = "2.1.0", features = [] }
+tauri-build = { version = "2.1.1", features = [] }
 
 [dependencies]
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
-tauri = { version = "2.4.0", features = [] }
+tauri = { version = "2.4.1", features = [] }
 tauri-plugin-devtools = "2.0.0"
 
 [features]


### PR DESCRIPTION
This pull request includes updates to the `Cargo.toml` file in the `src-tauri` directory to upgrade the versions of some dependencies.

Dependency version updates:

* Updated `tauri-build` from version `2.1.0` to `2.1.1`.
* Updated `tauri` from version `2.4.0` to `2.4.1`.